### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ concepts, then you can:
 Ressources
 **********
 
-* Documentation: https://django-confit.readthedocs.org
+* Documentation: https://django-confit.readthedocs.io
 * PyPI page: https://pypi.python.org/pypi/django-confit/
 * Code repository: https://github.com/benoitbryon/django-confit
 * Bugtracker: https://github.com/benoitbryon/django-confit/issues

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -15,7 +15,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 VERSION = open(os.path.join(project_root, 'VERSION')).read().strip()
 AUTHOR = u'Benoît Bryon'
 EMAIL = u'benoit@marmelune.net'
-URL = 'https://{name}.readthedocs.org/'.format(name=NAME)
+URL = 'https://{name}.readthedocs.io/'.format(name=NAME)
 CLASSIFIERS = ['Development Status :: 3 - Alpha',
                'License :: OSI Approved :: BSD License',
                'Programming Language :: Python :: 2.7',

--- a/docs/third-party.txt
+++ b/docs/third-party.txt
@@ -28,8 +28,8 @@ Here is the list of configuration schemas implemented as part of
    there is only one valid schema for your app, and it lives within your app).
 
 .. _`Django`: https://docs.djangoproject.com/en/stable/ref/settings/
-.. _`django-debug-toolbar`: http://django-debug-toolbar.readthedocs.org/en/latest/configuration.html
+.. _`django-debug-toolbar`: https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html
 .. _`django-nose`: https://pypi.python.org/pypi/django-nose/
 .. _`django-pimpmytheme`: https://pypi.python.org/pypi/django-pimpmytheme/
-.. _`django-pipeline`: http://django-pipeline.readthedocs.org/en/latest/configuration.html
-.. _`raven`: http://raven.readthedocs.org/en/latest/integrations/django.html
+.. _`django-pipeline`: https://django-pipeline.readthedocs.io/en/latest/configuration.html
+.. _`raven`: https://raven.readthedocs.io/en/latest/integrations/django.html

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ DESCRIPTION = 'Django settings loaders and validators, with local flavour.'
 VERSION = open(os.path.join(here, 'VERSION')).read().strip()
 AUTHOR = u'Benoît Bryon'
 EMAIL = 'benoit@marmelune.net'
-URL = 'https://django-confit.readthedocs.org'
+URL = 'https://django-confit.readthedocs.io'
 CLASSIFIERS = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
